### PR TITLE
Document 204 response for empty orders

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -318,7 +318,8 @@ paths:
         **Notes**
         
         * The default sort is by order id, from lowest to highest.
-        * By default, requests sent without parameters will only return 50 orders. 
+        * By default, requests sent without parameters will only return 50 orders.
+        * If no orders match the query, the endpoint returns a 204 No Content response.
 
       tags:
         - Orders
@@ -346,6 +347,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/orderCollection_Resp'
+        '204':
+          description: No Content
       summary: Get All Orders
       operationId: getOrders
     post:


### PR DESCRIPTION
## Summary
- clarify `Get All Orders` returns 204 when there are no orders
- document the 204 response in the spec

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685d732055d8832f97592ec9bc09b9b8